### PR TITLE
Updated transformers-supply to work with more recent versions of mtl.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Version 0.2.0
+
+- Added support for the `ExceptT` transformer.
+- Added lifted `MonadError` and `MonadReader` instances.
+- Removed support for the deprecated `ListT` transformer.
+- Removed support for the deprecated `ErrorT` transformer.

--- a/Control/Monad/Supply/Class.hs
+++ b/Control/Monad/Supply/Class.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
 -------------------------------------------------------------------------------
 -- |
@@ -20,9 +19,8 @@ module Control.Monad.Supply.Class (
 
 import Control.Monad.Trans
 import Control.Monad.Trans.Cont
-import Control.Monad.Trans.Error
+import Control.Monad.Trans.Except
 import Control.Monad.Trans.Identity
-import Control.Monad.Trans.List
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Reader
 import qualified Control.Monad.Trans.RWS.Lazy as LazyRWS
@@ -33,8 +31,6 @@ import Control.Monad.Trans.Supply (SupplyT)
 import qualified Control.Monad.Trans.Supply as Supply
 import Control.Monad.Trans.Writer.Lazy as Lazy
 import Control.Monad.Trans.Writer.Strict as Strict
-
-import Data.Monoid
 
 -- | The 'MonadSupply' class provides access to the functions needed to
 -- construct supply-consuming computations in a monad transformer stack.
@@ -60,15 +56,11 @@ instance MonadSupply s f m => MonadSupply s f (ContT r m) where
     supply = lift . supply
     provide = lift . provide
 
-instance (Error e, MonadSupply s f m) => MonadSupply s f (ErrorT e m) where
+instance (MonadSupply s f m) => MonadSupply s f (ExceptT e m) where
     supply = lift . supply
     provide = lift . provide
 
 instance MonadSupply s f m => MonadSupply s f (IdentityT m) where
-    supply = lift . supply
-    provide = lift . provide
-
-instance MonadSupply s f m => MonadSupply s f (ListT m) where
     supply = lift . supply
     provide = lift . provide
 

--- a/transformers-supply.cabal
+++ b/transformers-supply.cabal
@@ -1,5 +1,5 @@
 Name:                transformers-supply
-Version:             0.1.0
+Version:             0.2.0
 
 Homepage:            https://github.com/merijn/transformers-supply
 Bug-Reports:         https://github.com/merijn/transformers-supply/issues


### PR DESCRIPTION
Heya @merijn! I've made several changes to the code:

I've:
- removed support for the deprecated monads (`ErrorT` and `ListT`).
- added support for the new `ExceptT`; and
- added derived instances for `MonadError` and `MonadReader`, *i.e.*,

  ```haskell
  instance MonadError e m => MonadError e (SupplyT s m) where
  instance MonadReader r m => MonadReader r (SupplyT s m) where
  ```
  It should be noted that you're not exporting the constructor for `SupplyT`, so it's not possible to declare these instances outside of this package.

I should probably have added derived instances for `MonadWriter` and `MonadState` as well, but I couldn't quite figure out how to do the lifting.